### PR TITLE
Fixed manifest to support chromium browsers and more url paths

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,15 +1,16 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "BigBlueButton Plus",
-  "version": "2.0.2",
-  "description": "Individuelle Lautstärke für einzelne Teilnehmer & mehr -die perfekte Ergänzung für BBB Meetings",
+  "version": "2.1.0",
+  "description": "Individuelle Lautstärke für einzelne Teilnehmer & mehr - die perfekte Ergänzung für BBB Meetings",
   "icons": {
     "128": "128.png"
   },
   "content_scripts": [
     {
       "matches": [
-        "https://*/html5client/join*"
+        "https://*/html5client/join*",
+        "https://*/*/html5client/join*"
       ],
       "js": [
         "volume.js"

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": 3,
+  "manifest_version": 2,
   "name": "BigBlueButton Plus",
-  "version": "2.1.0",
+  "version": "2.0.3",
   "description": "Individuelle Lautstärke für einzelne Teilnehmer & mehr - die perfekte Ergänzung für BBB Meetings",
   "icons": {
     "128": "128.png"


### PR DESCRIPTION
Huhu,
ich schieße mal den PR einfach hier rein;

mit den manifest Changes funktioniert die Extension as-is auch unter Chromium, plus der match Change deckt BBB Hostings ab wo noch ein Step vor dem html5client klemmt, das ist z.B. bei uns an der Uni so :)

Einziger issue ist, dass Chromium den `applications` key im manifest nicht versteht, da beschwert er sich zwar aber ignoriert das dann auch einfach - hat also soweit ich sagen kann keinen impact `¯\_(ツ)_/¯`
Da wüsste ich auch nicht, wie man das fixen sollte ohne branching.